### PR TITLE
Example cross token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ script:
   - make -C python
   - make -C solidity
   - make end-to-end
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/1f272f1a71c54afe08e7
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ end-to-end:
 
 	make -C python lithium-a2b > /dev/null &
 	make -C python lithium-b2a > /dev/null &
+
 	make -C python example-pingpong
+	make -C python example-tokenproxy
+
 	make stop-end-to-end
 
 stop-end-to-end:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Panautoma 
+# Panautomata
 
 [![Build Status](https://travis-ci.org/HarryR/panautomata.svg?branch=master)](https://travis-ci.org/HarryR/panautomata)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Panautomata
 
-[![Build Status](https://travis-ci.org/HarryR/panautomata.svg?branch=master)](https://travis-ci.org/HarryR/panautomata)
+[![Build Status](https://travis-ci.org/HarryR/panautomata.svg?branch=master)](https://travis-ci.org/HarryR/panautomata) [![Join the chat at https://gitter.im/HarryR/panautomata](https://badges.gitter.im/harryr/panautomata.svg)](https://gitter.im/harryr/panautomata?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This is a research project to make it easy for developers to write smart contracts which run across multiple block-chains without the complex underlying logic that makes it possible.
 

--- a/docs/MarketingNotes.md
+++ b/docs/MarketingNotes.md
@@ -1,0 +1,13 @@
+# Marketing Notes
+
+## Distributed Ledgers, Working Together
+
+While your ledger may be distributed, what about the blockchain diaspora?
+
+There isn't a one-size-fits-all solution for blockchain or distributed ledgers, nor can one be expected to upgrade all of the systems at the click of a finger as soon as the latest fad comes along (e.g. blockchain).
+
+So, what bridges the gap between these dispirate systems and provides all of the guarantees and advantages of the new technologies which are are disrupting global finance?
+
+## Blockchain on-ramp
+
+TL;DR: Interoperability, Interoperability, Interoperability, *Steve Balmer throws chair*.

--- a/docs/MerkleProof.md
+++ b/docs/MerkleProof.md
@@ -4,26 +4,19 @@ All integers are encoded in big-endian format (most significant bit first).
 
 ## Leaf Format
 
-```
-
- +------------+-------------------+-----------+-----------------+
- | block hash | transaction index | log index | HASH(leaf_data) |
- +------------+-------------------+-----------+-----------------+
- |  32 bytes  |      32 bits      |  32 bits  |    32 bytes     |
- |            |      integer      |  integer  |    keccak256    |
-
-```
+| block hash | transaction index | log index | HASH(leaf_data) |
+| ---------- | ----------------- | --------- | --------------- |
+|  32 bytes  |      32 bits      |  32 bits  |    32 bytes     |
+|            |      integer      |  integer  |    keccak256    |
 
 ## Proof Format
 
-```
-                                                                        [ optional   ..
-              +--------------+-------------------+-----------+----------+----------+--
-              | block height | transaction index | log index |  Path 0  |  Path N  | ..
-              +--------------+-------------------+-----------+----------+----------+--
-              |   64 bits    |      32 bits      |  32 bits  | 32 bytes | 32 bytes | .. 
-              |   integer    |      integer      |  integer  |          |          |
-```
+|              |                   |           |          | optional | .. |
+| block height | transaction index | log index |  Path 0  |  Path N  | .. |
+| ------------ | ----------------- | --------- | -------- | -------- | -- |
+|   64 bits    |      32 bits      |  32 bits  | 32 bytes | 32 bytes | .. |
+|   integer    |      integer      |  integer  |          |          |    |
+
 
 The proof requires additional data for the leaf to be reconstructed, namely the `block_hash` field and the `leaf_data` field. The `block_hash` field is retrieved from on-chain storage based on the `block_height` field, and the `leaf_data` field is reconstructed using parameters from the contract and any other information which may be specific to the protocol or application being implemented
 
@@ -32,24 +25,18 @@ Each proof is at at minimum 48 bytes (with the minimum of 1 item in the Merkle t
 
 # Ethereum Leaf Format
 
+For Ethereum events and transactions only the absolutely necessary information is recorded in each leaf.
+
 ## Transaction
 
-
-```
- +--------------+------------+----------+------------------------+
- | from address | to address |  value   | HASH(selector || args) |
- +--------------+------------+----------+------------------------+
- |  20 bytes    |  20 bytes  | 256 bits |       32 bytes         |
- |  address     |  address   | integer  |    keccak-256 hash     |
-```
+| from address | to address |  value   | HASH(selector || args) |
+| ------------ | -----------| -------- | ---------------------- |
+|  20 bytes    |  20 bytes  | 256 bits |       32 bytes         |
+|  address     |  address   | integer  |    keccak-256 hash     |
 
 ## Event
 
-
-```
- +------------------+-----------+-------------+
- | contract address |   topic   |  HASH(args) |
- +------------------+-----------+-------------+
- |     20 bytes     |  32 bytes |   32 bytes  |
- |     address      |           |   keccak256 |
-```
+| contract address |   topic   |  HASH(args) |
+| ---------------- | --------- | ----------- |
+|     20 bytes     |  32 bytes |   32 bytes  |
+|     address      |           |   keccak256 |

--- a/docs/MerkleProof.md
+++ b/docs/MerkleProof.md
@@ -11,9 +11,9 @@ All integers are encoded in big-endian format (most significant bit first).
 
 ## Proof Format
 
-|              |                   |           |          | optional | .. |
 | block height | transaction index | log index |  Path 0  |  Path N  | .. |
 | ------------ | ----------------- | --------- | -------- | -------- | -- |
+|              |                   |           |          | optional | .. |
 |   64 bits    |      32 bits      |  32 bits  | 32 bytes | 32 bytes | .. |
 |   integer    |      integer      |  integer  |          |          |    |
 
@@ -29,10 +29,10 @@ For Ethereum events and transactions only the absolutely necessary information i
 
 ## Transaction
 
-| from address | to address |  value   | HASH(selector || args) |
-| ------------ | -----------| -------- | ---------------------- |
-|  20 bytes    |  20 bytes  | 256 bits |       32 bytes         |
-|  address     |  address   | integer  |    keccak-256 hash     |
+| from address | to address |  value   | HASH(selector,args) |
+| ------------ | ---------- | -------- | ------------------- |
+|  20 bytes    |  20 bytes  | 256 bits |       32 byte       |
+|  address     |  address   | integer  |   keccak-256 hash   |
 
 ## Event
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -46,6 +46,9 @@ lithium-b2a:
 lithium-%-stop: .lithium.%.pid
 	if [ -f $< ]; then kill -INT `cat $<` || true; fi; rm -f $<;
 
+example-tokenproxy:
+	$(PYTHON) -m$(NAME).example.tokenproxy
+
 example-pingpong:
 	$(PYTHON) -m$(NAME).example.pingpong
 

--- a/python/panautomata/example/tokenproxy.py
+++ b/python/panautomata/example/tokenproxy.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2018 HarryR. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0+
+
+from random import randint
+
+from ..utils import require
+from ..ethrpc import EthJsonRpc
+from ..lithium.common import proof_for_tx, link_wait
+
+
+LINK_ADDRESS = '0xcfeb869f69431e42cdb54a4f4f105c19c080a601'
+PROVER_ADDR = '0xe982e462b094850f12af94d21d470e21be9d0e9c'
+
+LOCK_CONTRACT_ADDR = '0x0290fb167208af455bb137780163b7b7a9a10c16'
+TOKEN_CONTRACT_ADDR = '0x9b1f7f645351af3631a656421ed2e40f2802e6c0'
+
+ACCOUNT_ADDR = '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1'
+
+
+def main():
+
+    rpc_a = EthJsonRpc('127.0.0.1', 8545)
+    link_a = rpc_a.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDRESS)
+    lock_contract = rpc_a.proxy('../solidity/build/contracts/ExampleCrossTokenLock.json', LOCK_CONTRACT_ADDR, ACCOUNT_ADDR)
+
+    rpc_b = EthJsonRpc('127.0.0.1', 8546)
+    link_b = rpc_b.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDRESS)
+    token_contract = rpc_b.proxy('../solidity/build/contracts/ExampleCrossTokenProxy.json', TOKEN_CONTRACT_ADDR, ACCOUNT_ADDR)
+
+    token_remote = (PROVER_ADDR, 1, TOKEN_CONTRACT_ADDR)
+    lock_remote = (PROVER_ADDR, 1, LOCK_CONTRACT_ADDR)
+
+    deposit_value = randint(2 << 10, 2 << 15)
+    half_deposit_value = deposit_value // 2
+
+    # make Deposit() with Value on chain A and verify balance
+    print("A: Deposit")
+    start_balance = rpc_a.eth_getBalance(LOCK_CONTRACT_ADDR)
+    deposit_tx = lock_contract.Deposit(token_remote, value=deposit_value)
+    deposit_receipt = deposit_tx.wait()
+    print(" - deposit receipt:", deposit_receipt)
+    deposit_proof = proof_for_tx(rpc_a, deposit_tx)
+
+    after_deposit_balance = rpc_a.eth_getBalance(LOCK_CONTRACT_ADDR)
+    require((after_deposit_balance - start_balance) == deposit_value, "Deposit value mismatch")
+
+    # Wait for deposit proof on chain B
+    link_wait(link_b, deposit_proof)
+
+    # Perform redemption of tokens equivalent to deposited value
+    print("B: Redeem")
+    tokens_before_redeem = token_contract.balanceOf(ACCOUNT_ADDR)
+    redeem_tx = token_contract.Redeem(lock_remote, token_remote, deposit_value, deposit_proof)
+    redeem_receipt = redeem_tx.wait()
+    print(" - redeem receipt:", redeem_receipt)
+    tokens_after_redeem = token_contract.balanceOf(ACCOUNT_ADDR)
+    require((tokens_after_redeem - tokens_before_redeem) == deposit_value)
+
+    # perform Burn() on chain B of half the number of tokens
+    print("B: Burn")
+    burn_tx = token_contract.Burn(half_deposit_value)
+    burn_receipt = burn_tx.wait()
+    print(" - burn receipt:", burn_receipt)
+    burn_proof = proof_for_tx(rpc_b, burn_tx)
+    tokens_after_burn = token_contract.balanceOf(ACCOUNT_ADDR)
+    require((tokens_after_redeem - tokens_after_burn) == half_deposit_value)
+
+    # Wait for burn proof on chain A
+    link_wait(link_a, burn_proof)
+
+    # on chain A perform Withdraw(), provide proof of Burn
+    print("A: Withdraw")
+    withdraw_tx = lock_contract.Withdraw(token_remote, half_deposit_value, burn_proof)
+    withdraw_receipt = withdraw_tx.wait()
+    print(" - withdraw receipt:", withdraw_receipt)
+    after_withdraw_balance = rpc_a.eth_getBalance(LOCK_CONTRACT_ADDR)
+    require((after_deposit_balance - after_withdraw_balance) == half_deposit_value)
+
+
+if __name__ == "__main__":
+    main()

--- a/solidity/contracts/example/ExampleCrossToken.sol
+++ b/solidity/contracts/example/ExampleCrossToken.sol
@@ -1,0 +1,124 @@
+// Copyright (c) 2018 HarryR. All Rights Reserved.
+// SPDX-License-Identifier: GPL-3.0+
+
+pragma solidity 0.4.24;
+pragma experimental "v0.5.0";
+pragma experimental ABIEncoderV2;
+
+import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+import "../Panautoma.sol";
+
+
+/*
+* Provides a mechanism for depositing Ether on one chain and then
+* using it tokenized form on another chain. Any tokens given to anybody
+* on the other chain can be redeemed on the other chain for its original
+* value.
+*
+* This is made possible by making sure that value can only be on one place
+* at any one point in time. To use value on another chain you must first
+* ensure that it can't be used anywhere else.
+*
+* So, you deposit your value onto a lock on Chain A, in a way which can only
+* be withdrawn on Chain B (in tokenized form), this creates N 'meta tokens'
+* of 'N of X from A on B'.
+*
+* If you are given M tokens of the 'N of X from A on B' tokens, you can
+* 'burn' then on chain B, then on Chain A the proof of Burn can be redeemed
+* for M tokens of the original value.
+*/
+
+
+/**
+* The lock contract can have Ether deposited into it, to be redeemed on
+* another chain in tokenized form by the specified address. Once deposited
+* it cannot be withdrawn until the person it was deposited for provides
+* proof of burn from the other chain.
+*/
+contract ExampleCrossTokenLock
+{
+	using RemoteContractLib for Panautoma.RemoteContract;
+
+	mapping( bytes32 => uint256 ) m_deposits;
+
+
+	function Deposit ( Panautoma.RemoteContract in_remote )
+		public payable
+	{
+		// Deposit creates proof that value has been locked
+
+		// TODO: hash in_remote, increment m_deposits[x]
+	}
+
+
+	function Withdraw ( uint256 in_amount, bytes in_proof )
+		public
+	{
+		// Proof of Burn allows Withdraw
+
+		// Verify m_deposits is greater or equal to withdraw amount
+
+		bool tx_ok = in_remote.VerifyTransaction(
+			msg.sender,
+			0,
+			bytes4(ExampleCrossTokenProxy.Burn.selector),
+			abi.encode(in_amount),
+			in_proof
+		);
+		require( tx_ok );
+
+		msg.sender.transfer(in_amount);
+	}
+}
+
+
+/**
+* The proxy token contract allows others to redeem tokens of
+* equivalent value if deposited on the original chain.
+*
+* Upon 'Burning' these tokens, the proof of burn can be used
+* to 'Withdraw' the original value on the original chain.
+*/
+contract ExampleCrossTokenProxy is StandardToken
+{
+	using RemoteContractLib for Panautoma.RemoteContract;
+
+	using SafeMath for uint256;
+
+
+	function Redeem ( Panautoma.RemoteContract in_remote, uint256 in_amount, bytes in_proof )
+		public
+	{
+		// Proof of Deposit allows Redeem on this chain
+
+		// Remote contract must be ourselves
+		require( in_remote.addr == this );
+
+		// Proof of a Deposit transaction on the other side
+		bool tx_ok = in_remote.VerifyTransaction(
+			msg.sender,
+			in_amount,
+			bytes4(ExampleCrossTokenLock.Deposit.selector),
+			abi.encode(in_remote),
+			in_proof
+		);
+		require( tx_ok );
+
+		totalSupply_.add(in_amount);
+
+		balances[msg.sender].add(in_amount);
+	}
+
+
+	function Burn ( uint256 in_amount )
+		public
+	{
+		// Proof of Burn allows Withdraw on original chain
+
+		balances[msg.sender].sub(in_amount);
+
+		totalSupply_.sub(in_amount);
+	}
+}

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -6,6 +6,8 @@ const ExampleERC20Token = artifacts.require("ExampleERC20Token");
 const ExamplePingPongA = artifacts.require("ExamplePingPongA");
 const ExamplePingPongB = artifacts.require("ExamplePingPongB");
 const Registrar = artifacts.require("Registrar");
+const ExampleCrossTokenLock = artifacts.require("ExampleCrossTokenLock");
+const ExampleCrossTokenProxy = artifacts.require("ExampleCrossTokenProxy");
 
 module.exports = async (deployer, network, accounts) => {
     await deployer.deploy(MockProofVerifier);
@@ -20,4 +22,7 @@ module.exports = async (deployer, network, accounts) => {
     await deployer.deploy(LithiumProver, link.address);
 
     await deployer.deploy(Registrar, accounts[0]);
+
+    await deployer.deploy(ExampleCrossTokenLock);
+    await deployer.deploy(ExampleCrossTokenProxy);
 };

--- a/solidity/test/TestLithiumLink.sol
+++ b/solidity/test/TestLithiumLink.sol
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 HarryR. All Rights Reserved.
+// SPDX-License-Identifier: GPL-3.0+
+
 pragma solidity 0.4.24;
 
 import "truffle/Assert.sol";

--- a/solidity/test/TestLithiumProver.sol
+++ b/solidity/test/TestLithiumProver.sol
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 HarryR. All Rights Reserved.
+// SPDX-License-Identifier: GPL-3.0+
+
 pragma solidity 0.4.24;
 
 import "truffle/Assert.sol";

--- a/solidity/test/TestMerkle.sol
+++ b/solidity/test/TestMerkle.sol
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 HarryR. All Rights Reserved.
+// SPDX-License-Identifier: GPL-3.0+
+
 pragma solidity 0.4.24;
 
 import "truffle/Assert.sol";


### PR DESCRIPTION
This examples allows you to lock tokens on one chain, then redeem them on another chain as tokens.

Any tokens on the other chain can be burned, then the original value withdrawn on the original chain.

This allows you to, for example, deposit Ether on Ropsten, then on Kovan use the tokenized Ropsten-Ether, transfer it to people or whatever... then whoever holds the tokens can burn them and withdraw the original Ropsten Ether back on Ropsten.