### PR TITLE
Cross token security

### DIFF
--- a/python/panautomata/example/pingpong.py
+++ b/python/panautomata/example/pingpong.py
@@ -61,7 +61,7 @@ def main():
     # Sends proof of Ping from B to A
     # Then proof of Pong from A to B
     # Repeated ad infinitum
-    for _ in range(0, 5):
+    for _ in range(0, 3):
         # Provide proof of the 'Ping' event
         print("ReceivePing")
         link_wait(link_a, ping_proof)

--- a/solidity/contracts/Panautoma.sol
+++ b/solidity/contracts/Panautoma.sol
@@ -18,6 +18,16 @@ library Panautoma
 
 library RemoteContractLib
 {
+    function GUID (Panautoma.RemoteContract self)
+        internal pure returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(
+            address(self.prover),
+            self.nid,
+            self.addr)
+        );
+    }
+
     function VerifyEvent( Panautoma.RemoteContract self, bytes32 in_event_sig, bytes in_event_args, bytes in_proof )
         internal view returns (bool)
     {

--- a/solidity/contracts/example/ExampleCrossToken.sol
+++ b/solidity/contracts/example/ExampleCrossToken.sol
@@ -84,6 +84,12 @@ contract ExampleCrossTokenLock
 }
 
 
+// TODO: add a factory contract which creates the token contracts for each source
+//       you query the main contract for which contract exists that can be a proxy
+//       if it returns none, then you tell it to create a contract, which can be used
+//       in future if you request tokens from the same source.
+
+
 /**
 * The proxy token contract allows others to redeem tokens of
 * equivalent value if deposited on the original chain.

--- a/solidity/contracts/example/ExampleCrossToken.sol
+++ b/solidity/contracts/example/ExampleCrossToken.sol
@@ -52,7 +52,7 @@ contract ExampleCrossTokenLock
     {
         // Deposit creates proof that value has been locked
 
-        bytes32 l_rchash = HashRemoteContract(in_remote);
+        bytes32 l_rchash = in_remote.GUID();
 
         m_deposits[l_rchash] = m_deposits[l_rchash].add(msg.value);
     }
@@ -63,9 +63,9 @@ contract ExampleCrossTokenLock
     {
         // Proof of Burn allows Withdraw
 
-        // Verify m_deposits is greater or equal to withdraw amount
-        bytes32 l_rchash = HashRemoteContract(in_remote);
+        bytes32 l_rchash = in_remote.GUID();
 
+        // Verify m_deposits is greater or equal to withdraw amount
         require( m_deposits[l_rchash] >= in_amount );
 
         bool tx_ok = in_remote.VerifyTransaction(
@@ -81,18 +81,6 @@ contract ExampleCrossTokenLock
 
         msg.sender.transfer(in_amount);
     }
-
-
-    function HashRemoteContract (Panautoma.RemoteContract in_remote)
-        internal pure returns (bytes32)
-    {
-        return keccak256(abi.encodePacked(
-            address(in_remote.prover),
-            in_remote.nid,
-            in_remote.addr)
-        );
-    }
-
 }
 
 
@@ -109,13 +97,20 @@ contract ExampleCrossTokenProxy is StandardToken
 
     using SafeMath for uint256;
 
-    // XXX/SECURITY: this allows tokens of mixed origins to be mixed together
-    // This contract must be locked to a specific remote contract upon first use.
+    bytes32 internal m_locked_to;
 
+
+    // Proof of Deposit allows Redeem on this chain
     function Redeem ( Panautoma.RemoteContract in_lock_remote, Panautoma.RemoteContract in_self_remote, uint256 in_amount, bytes in_proof )
         public
     {
-        // Proof of Deposit allows Redeem on this chain
+        // Upon first redemption this contract is locked to a specific remote
+        // lock contract, this prevents mixing of tokens from multiple sources.
+        if (m_locked_to != 0x0) {
+            require( m_locked_to == in_lock_remote.GUID() );
+        } else {
+            m_locked_to = in_lock_remote.GUID();
+        }
 
         // Remote contract must be ourselves
         require( in_self_remote.addr == address(this) );


### PR DESCRIPTION
… from multiple sources

The contract is locked to the first source which redeems tokens.

This prevents the situation:

 * Redeem Ether from remote contract A
 * Redeem Ether from remote contract B
 * What is the real value of the token held by the contract?