### PR TITLE
Example swap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ end-to-end:
 
 	make -C python example-pingpong
 	make -C python example-tokenproxy
+	make -C python example-swap
 
 	make stop-end-to-end
 

--- a/docs/AtomicSwap.md
+++ b/docs/AtomicSwap.md
@@ -1,0 +1,8 @@
+# Atomic Swap Example
+
+The atomic swap example uses cross-chain proofs of transactions and events to perform an atomic cross-chain token swap between two parties in a way that, in an atomic fashion, either the swap can happen or both can be refunded - this is an absolute guarantee as long as the event proofing source is updated, unlike using a HTLC (pre-image lock with expiry) where one side can be left at a disadvantage if they miss the expiry time.
+
+
+## State Machine
+
+![Atomic Swap State Machine](https://i.imgur.com/RnHKrn1.png)

--- a/docs/Proposal.md
+++ b/docs/Proposal.md
@@ -1,0 +1,83 @@
+# Distributed State Machine Research Proposal
+
+## Preface
+
+Plasma chains solve a small part of the scaling problem by providing a limited communication method between concurrent domains while ensuring that state (or... value?) can only exist in one place at a time, it is by definion a finite state machine of sorts - albeit with significant constraints.
+
+However, what if part of the scaling problem is more than just the transfer of value between concurrent domains? Both Polkadot and Cosmos identified this problem and sought to find a solution - acting as a general purpose messaging layer, but without the right kind of research I believe they're missing a crucial part of the problem; this is something I wish to address to the benefit of not only the Ethereum ecosystem, but for general purpose distributed computation as a concept.
+
+As with storage of value via cryptographic proof of work (hashcash), then arbitrary programmable transactions in a single place (albeit distributed and secured by the Bitcoin network), then the application of general purpose computation to the same problem (Ethereum) - this project aims to strive towards finding the next exponentially useful leap by making it easier for dispirate systems to work together with the same guarantees of everything that they build upon - and more - or at least, to attempt to scratch the surface of the problem.
+
+
+### Outline
+
+This research project aims to create a more formalised definition of a distributed finite state machine and its limitations specifically in the blockchain and Ethereum context. It will be achieved by creating prototypes of different use-cases which require cross-chain communication and a finite state being maintained in a distributed environment, initially using proof of state from a trusted authority, hand-written solidity contracts that implement the state machines and client-side examples that make operating the state machines seamless to the developer.
+
+The aims for this research project are to:
+
+ 1. Make it easy for developers to model, implement and use cross-chain state machines
+ 2. Realise a notation for distributed state machines, which includes the transfer of state and value, and concurrent states (like workflows, and BPMN)
+ 3. Determine when state channels can be used, and automatically condense multiple state transitions into fewer on-chain operations
+ 4. Explore mechanisms to ensure that state transitions are atomic and unidirectional
+ 5. Reflect upon value versus state, and whether or not game theory can be applied
+
+
+### Plasma, value versus state
+
+The exit conditions for Plasma have become an interesting talking point because it creates a game-theoretic condition in which adhering the rules is less costly than any gain you could realise from breaking them.
+
+But, what happens when the value of a state isn't deterministic, where there is no zero-sum game, and the value of a single state transition may be unknowable to any observer?
+
+A speculative aim of this research is, by working through many different use cases and the theory of distributed finite state machines, to try to curate an alternate perspective where concurrency is king - rather than just value being in one place at a time.
+
+
+## Research Deliverables
+
+I firmly believe that there are two aspects to the value of research:
+
+ 1. Delivering something that can be used, by people, realistically
+ 2. Identifying, solving and pushing the edge cases where it can't yet be used
+
+So, what can I deliver that will help make this happen, without getting caught up in grand-scheme-of-things thinking?
+
+ * Further examples, other than ping-pong, remote-token and atomic-swap
+ * Notation and visualisation for the state machines
+ * Automatic translation from state machine to smart contract
+ * Client-side library to make interracting with the state machines easy
+ * Documentation of edge cases
+   * Limitations of finite state machines (e.g. split/join, concurrency, workflows)
+   * State compression, via state channels
+ * Proof of concept of state-machine compression (state channels)
+
+Ultimately the aim is to deliver developer tools, libraries and related programs and supporting documentation so that this work can be used and deployed 
+
+## Timespans
+
+Building upon the work in the Panautomata repository:
+
+ * month 1
+   * notation of simple distributed state machines
+   * proof of concept, translating state machine notation into smart contract and client-side-code
+   * integrating generated state machines with solidity code
+ * month 2
+   * further examples and client-side library improvements
+   * pluggable proofing mechanisms
+     * proof of concept using Ethereum block headers, merkle-patricia trie receipts etc.
+     * research for Polkadot and Cosmos integration
+ * month 3
+   * documentation of edge cases (concurrency, split, join, failure)
+   * analyse latest available research on state channels
+   * automatic state compression (state channel) specification, by analysing state machine notation
+   * client-side and on-chain state channel tools / libraries / simple proofs of concept
+ * month 4
+   * extend examples to support state compression
+   * proof of concept end-to-end example using state compression
+   * proof of concept of automatic state compression
+ * month 5
+   * retrospective
+   * documentation
+   * deployment considerations
+
+The month to month goals seem reasonable, well scoped and build ontop of each other, however as with any plan this is speculative - however, at each month the focus will be on making sure that the previous months work is in a usable, tested and publicly consumable state. 
+
+Monthly summaries of work-to-date, progress, achievements and deviations from the plan will be provided, with weekly development updates.

--- a/python/panautomata/__main__.py
+++ b/python/panautomata/__main__.py
@@ -4,12 +4,10 @@ import click
 # TODO: setup logger here, must setup logger before modules are imported
 
 from .lithium.cli import daemon as lithium_daemon
-from .example.swap import COMMANDS as swap_commands
 
 
 COMMANDS = click.Group()
 COMMANDS.add_command(lithium_daemon, name="lithium")
-COMMANDS.add_command(swap_commands)
 
 
 if __name__ == "__main__":

--- a/python/panautomata/ethrpc.py
+++ b/python/panautomata/ethrpc.py
@@ -141,7 +141,7 @@ class EthTransaction(namedtuple('_TxStruct', ('rpc', 'txid'))):
             # TODO: turn into asynchronous notification / future
             if receipt:
                 if raise_on_error and receipt['status'] == '0x0':
-                    raise RuntimeError("Receipt error! - " + receipt)
+                    raise RuntimeError("Receipt error! - " + str(receipt))
                 return receipt
             if not wait:
                 break

--- a/python/panautomata/ethrpc.py
+++ b/python/panautomata/ethrpc.py
@@ -123,14 +123,14 @@ class EthTransaction(namedtuple('_TxStruct', ('rpc', 'txid'))):
             txid = '0x' + txid
         return self.rpc.eth_getTransactionByHash(txid)
 
-    def wait(self):
-        return self.receipt(wait=True)
+    def wait(self, raise_on_error=False):
+        return self.receipt(wait=True, raise_on_error=raise_on_error)
 
     def success(self, wait=True):
         receipt = self.receipt(wait=wait)
         return receipt['status'] != '0x0'
 
-    def receipt(self, wait=False, tick_fn=None):
+    def receipt(self, wait=False, tick_fn=None, raise_on_error=False):
         # TODO: add `timeout` param
         first = True
         txid = self.txid
@@ -140,6 +140,8 @@ class EthTransaction(namedtuple('_TxStruct', ('rpc', 'txid'))):
             receipt = self.rpc.eth_getTransactionReceipt(txid)
             # TODO: turn into asynchronous notification / future
             if receipt:
+                if raise_on_error and receipt['status'] == '0x0':
+                    raise RuntimeError("Receipt error! - " + receipt)
                 return receipt
             if not wait:
                 break

--- a/python/panautomata/example/swap.py
+++ b/python/panautomata/example/swap.py
@@ -49,7 +49,6 @@ def main():
     token_a.approve(SWAP_CONTRACT, alice_value).wait(raise_on_error=True)
     require(token_a.allowance(ACCOUNT_ALICE, SWAP_CONTRACT) == alice_value)
 
-
     # Create Bob's tokens, approve swap contract to use them
     print("B: mint + approve")
     bob_balance_begin = token_b.balanceOf(ACCOUNT_BOB)
@@ -61,14 +60,12 @@ def main():
     token_b.approve(SWAP_CONTRACT, bob_value).wait(raise_on_error=True)
     require(token_b.allowance(ACCOUNT_BOB, SWAP_CONTRACT) == bob_value)
 
-
     # Session struct
     RC_ALICE = (PROVER_ADDR, 1, SWAP_CONTRACT)
     RC_BOB = (PROVER_ADDR, 1, SWAP_CONTRACT)
     SESSION_SIDE_ALICE = ((RC_ALICE), TOKEN_CONTRACT, ACCOUNT_ALICE, alice_value)
     SESSION_SIDE_BOB = ((RC_BOB), TOKEN_CONTRACT, ACCOUNT_BOB, bob_value)
     SESSION = (1, SESSION_SIDE_ALICE, SESSION_SIDE_BOB)
-
 
     # On chain A, perform Propose as Alice
     alice_balance_before_propose = token_a.balanceOf(ACCOUNT_ALICE)
@@ -83,7 +80,6 @@ def main():
     # Verify Alice's balance has reduced
     require(token_a.balanceOf(ACCOUNT_ALICE) == (alice_balance_before_propose - alice_value))
     require(token_a.balanceOf(SWAP_CONTRACT) == (swap_balance_before_propose + alice_value))
-
 
     # On chain B, perform Accept as Bob
     link_wait(link_b, propose_proof)
@@ -100,7 +96,6 @@ def main():
     require(token_b.balanceOf(ACCOUNT_BOB) == (bob_balance_before_accept - bob_value))
     require(token_b.balanceOf(SWAP_CONTRACT) == (swap_balance_before_accept + bob_value))
 
-
     # On chain A, perform Withdraw as Bob
     print("A: Bob Withdraw")
     bob_balance_before_withdraw = token_a.balanceOf(ACCOUNT_BOB)
@@ -114,7 +109,6 @@ def main():
     require(token_a.balanceOf(ACCOUNT_BOB) == (bob_balance_before_withdraw + alice_value))
     require(token_a.balanceOf(SWAP_CONTRACT) == (swap_a_balance_before_withdraw - alice_value))
 
-
     # On chain B, perform Withdraw as Alice
     print("B: Alice Withdraw")
     alice_balance_before_withdraw = token_b.balanceOf(ACCOUNT_ALICE)
@@ -126,7 +120,6 @@ def main():
     # Verify Alice now has bob's tokens
     require(token_b.balanceOf(ACCOUNT_ALICE) == (alice_balance_before_withdraw + bob_value))
     require(token_b.balanceOf(SWAP_CONTRACT) == (swap_b_balance_before_withdraw - bob_value))
-
 
 
 if __name__ == "__main__":

--- a/python/panautomata/example/swap.py
+++ b/python/panautomata/example/swap.py
@@ -49,6 +49,7 @@ def main():
     token_a.approve(SWAP_CONTRACT, alice_value).wait(raise_on_error=True)
     require(token_a.allowance(ACCOUNT_ALICE, SWAP_CONTRACT) == alice_value)
 
+
     # Create Bob's tokens, approve swap contract to use them
     print("B: mint + approve")
     bob_balance_begin = token_b.balanceOf(ACCOUNT_BOB)
@@ -60,12 +61,14 @@ def main():
     token_b.approve(SWAP_CONTRACT, bob_value).wait(raise_on_error=True)
     require(token_b.allowance(ACCOUNT_BOB, SWAP_CONTRACT) == bob_value)
 
+
     # Session struct
     RC_ALICE = (PROVER_ADDR, 1, SWAP_CONTRACT)
     RC_BOB = (PROVER_ADDR, 1, SWAP_CONTRACT)
     SESSION_SIDE_ALICE = ((RC_ALICE), TOKEN_CONTRACT, ACCOUNT_ALICE, alice_value)
     SESSION_SIDE_BOB = ((RC_BOB), TOKEN_CONTRACT, ACCOUNT_BOB, bob_value)
     SESSION = (1, SESSION_SIDE_ALICE, SESSION_SIDE_BOB)
+
 
     # On chain A, perform Propose as Alice
     alice_balance_before_propose = token_a.balanceOf(ACCOUNT_ALICE)
@@ -80,6 +83,7 @@ def main():
     # Verify Alice's balance has reduced
     require(token_a.balanceOf(ACCOUNT_ALICE) == (alice_balance_before_propose - alice_value))
     require(token_a.balanceOf(SWAP_CONTRACT) == (swap_balance_before_propose + alice_value))
+
 
     # On chain B, perform Accept as Bob
     link_wait(link_b, propose_proof)
@@ -96,26 +100,33 @@ def main():
     require(token_b.balanceOf(ACCOUNT_BOB) == (bob_balance_before_accept - bob_value))
     require(token_b.balanceOf(SWAP_CONTRACT) == (swap_balance_before_accept + bob_value))
 
-    # On chain B, perform Withdraw as Alice
-    print("B: Alice Withdraw")
-    alice_withdraw_tx = swap_b.TransitionAliceWithdraw(swap_guid)
-    alice_withdraw_receipt = alice_withdraw_tx.wait(raise_on_error=True)
-    print(" - alice withdraw receipt", alice_withdraw_receipt)
-
-    # Verify Alice now has bob's tokens
-    require(token_b.balanceOf(ACCOUNT_ALICE) == bob_value)
-    require(token_b.balanceOf(SWAP_CONTRACT) == 0)
 
     # On chain A, perform Withdraw as Bob
     print("A: Bob Withdraw")
+    bob_balance_before_withdraw = token_a.balanceOf(ACCOUNT_BOB)
+    swap_a_balance_before_withdraw = token_a.balanceOf(SWAP_CONTRACT)
     link_wait(link_a, accept_proof)
     bob_withdraw_tx = swap_a.TransitionBobWithdraw(swap_guid, accept_proof)
     bob_withdraw_receipt = bob_withdraw_tx.wait(raise_on_error=True)
     print(" - bob withdraw receipt", bob_withdraw_receipt)
 
     # Verify Bob now has Alice's tokens
-    require(token_a.balanceOf(ACCOUNT_BOB) == alice_value)
-    require(token_a.balanceOf(SWAP_CONTRACT) == 0)
+    require(token_a.balanceOf(ACCOUNT_BOB) == (bob_balance_before_withdraw + alice_value))
+    require(token_a.balanceOf(SWAP_CONTRACT) == (swap_a_balance_before_withdraw - alice_value))
+
+
+    # On chain B, perform Withdraw as Alice
+    print("B: Alice Withdraw")
+    alice_balance_before_withdraw = token_b.balanceOf(ACCOUNT_ALICE)
+    swap_b_balance_before_withdraw = token_b.balanceOf(SWAP_CONTRACT)
+    alice_withdraw_tx = swap_b.TransitionAliceWithdraw(swap_guid)
+    alice_withdraw_receipt = alice_withdraw_tx.wait(raise_on_error=True)
+    print(" - alice withdraw receipt", alice_withdraw_receipt)
+
+    # Verify Alice now has bob's tokens
+    require(token_b.balanceOf(ACCOUNT_ALICE) == (alice_balance_before_withdraw + bob_value))
+    require(token_b.balanceOf(SWAP_CONTRACT) == (swap_b_balance_before_withdraw - bob_value))
+
 
 
 if __name__ == "__main__":

--- a/python/panautomata/example/swap.py
+++ b/python/panautomata/example/swap.py
@@ -4,121 +4,102 @@
 from random import randint
 from enum import IntEnum
 
+from ..lithium.common import proof_for_tx, proof_for_event, link_wait
+
+
+PROVER_ADDR = '0xe982e462b094850f12af94d21d470e21be9d0e9c'
+LINK_ADDR = '0xcfeb869f69431e42cdb54a4f4f105c19c080a601'
 
 SWAP_CONTRACT = '0x254dffcd3277c0b1660f6d42efbb754edababc2b'
 TOKEN_CONTRACT = '0xc89ce4735882c9f0f0fe26686c53074e09b0d550'
 
-ACCOUNT_A = '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1'
-ACCOUNT_B = '0xffcf8fdee72ac11b5c542428b35eef5769c409f0'
-
-
-class SwapState(IntEnum):
-    Invalid = 0
-    AlicePropose = 1
-    AliceCancel = 2
-    AliceWithdraw = 3
-    AliceRefund = 4
-    BobAccept = 5
-    BobReject = 6
-    BobWithdraw = 7
-
-
-class SwapSide(object):
-    __slots__ = ('contract', 'token', 'address', 'amount')
-
-    def __init__(self, contract, token, address, amount):
-        # TODO: verify type of contract
-        # TODO: verify type of token
-        # TODO: verify type of address
-        assert isinstance(amount, int)
-        self.contract = contract  # ExampleSwap contract proxy
-        self.token = token        # ERC20 token contract proxy
-        self.address = address    # Of account
-        self.amount = amount      # Number of tokens
-
-
-class Swap(object):
-    __slots__ = ('state', 'alice_side', 'bob_side')
-
-    def __init__(self, state, alice_side, bob_side):
-        assert isinstance(state, SwapState)
-        assert isinstance(alice_side, SwapSide)
-        assert isinstance(bob_side, SwapSide)
-        self.state = state
-        self.alice_side = alice_side
-        self.bob_side = bob_side
-
-
-class SwapProposal(object):
-    __slots__ = ('swap', 'proof')
-
-    def __init__(self, swap, proof):
-        self.swap = swap
-        self.proof = proof
-
-    def cancel(self):
-        # TODO: on bob side, submit cancel transaction (as Alice)
-        pass
-
-    def wait(self):
-        # TODO: wait until Bob decides what to do with the swap
-        # Swap been accepted by Bob, Alice can now withdraw
-        return SwapConfirmed(self.swap.alice_side)
-
-    def accept(self):
-        # TODO: verify allowed balance on bob side
-        # TODO: allow balance on Bob side if needed
-        # TODO: on bob side, submit accept transaction (as Bob)
-        return SwapConfirmed(self.swap.bob_side)
-
-    def reject(self):
-        # TODO: on bob side, submit reject transaction (as Bob)
-        pass
-
-
-class SwapConfirmed(object):
-    __slots__ = ('side',)
-
-    def __init__(self, side):
-        assert isinstance(side, SwapSide)
-        self.side = side
-
-    def withdraw(self):
-        return True
-
-
-class SwapManager(object):
-    def __init__(self):
-        """
-        A and B side
-        On each side there are Token and ExampleSwap contracts
-        """
-        pass
-
-    def propose(self, alice_side, bob_side):
-        assert isinstance(alice_side, SwapSide)
-        assert isinstance(bob_side, SwapSide)
-        # TODO: verify allowed balance on Alice side
-        # TODO: allow balance on Alice side if needed
-        # TODO: submit proposal transaction
-        swap = None
-        proposal = None
-        return SwapProposal(swap, proposal)
+ACCOUNT_ALICE = '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1'
+ACCOUNT_BOB = '0xffcf8fdee72ac11b5c542428b35eef5769c409f0'
 
 
 def main():
     rpc_a = EthJsonRpc('127.0.0.1', 8545)
-    link_a = rpc_a.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDRESS)
-    swap_a = rpc_a.proxy('../solidity/build/contracts/ExampleSwap.json', SWAP_CONTRACT, ACCOUNT_A)
-    token_a = rpc_a.proxy('../solidity/build/contracts/ExampleERC20Token.json', TOKEN_CONTRACT ACCOUNT_A)
+    link_a = rpc_a.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDR)
+    swap_a = rpc_a.proxy('../solidity/build/contracts/ExampleSwap.json', SWAP_CONTRACT, ACCOUNT_ALICE)
+    token_a = rpc_a.proxy('../solidity/build/contracts/ExampleERC20Token.json', TOKEN_CONTRACT ACCOUNT_ALICE)
 
     rpc_b = EthJsonRpc('127.0.0.1', 8546)
-    link_b = rpc_b.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDRESS)
-    swap_b = rpc_b.proxy('../solidity/build/contracts/ExampleSwap.json', SWAP_CONTRACT ACCOUNT_B)
-    token_b = rpc_b.proxy('../solidity/build/contracts/ExampleERC20Token.json', TOKEN_CONTRACT ACCOUNT_B)
+    link_b = rpc_b.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDR)
+    swap_b = rpc_b.proxy('../solidity/build/contracts/ExampleSwap.json', SWAP_CONTRACT ACCOUNT_BOB)
+    token_b = rpc_b.proxy('../solidity/build/contracts/ExampleERC20Token.json', TOKEN_CONTRACT ACCOUNT_BOB)
 
     swap_guid = randint(1, 1<<255)
-    
+
+    alice_value = randint(1024, 10240)
+    bob_value = 0
+    while bob_value != alice_value:
+        bob_value = randint(1024, 10240)
+
+    # Create Alice's tokens, approve swap contract to use them
+    print("A: mint + approve")
+    token_a.mint(ACCOUNT_ALICE, alice_value).wait(raise_on_error=True)
+    require( token_a.balanceOf(ACCOUNT_ALICE) == alice_value )
+    token_a.approve(SWAP_CONTRACT, alice_value).wait(raise_on_error=True)
+    require( token_a.allowance(ACCOUNT_ALICE, SWAP_CONTRACT) == alice_value )
+
+    # Create Bob's tokens, approve swap contract to use them
+    print("B: mint + approve")
+    token_b.mint(ACCOUNT_BOB, bob_value).wait(raise_on_error=True)
+    require( token_b.balanceOf(ACCOUNT_BOB) == bob_value )
+    token_b.approve(SWAP_CONTRACT, bob_value).wait(raise_on_error=True)
+    require( token_b.allowance(ACCOUNT_BOB, SWAP_CONTRACT) == bob_value )
+
+    # Session struct
+    RC_ALICE = (PROVER_ADDR, 1, SWAP_CONTRACT)
+    RC_BOB = (PROVER_ADDR, 1, SWAP_CONTRACT)
+    SESSION_SIDE_ALICE = ((RC_ALICE), TOKEN_CONTRACT, ADDRESS_ALICE, alice_value)
+    SESSION_SIDE_BOB = ((RC_BOB), TOKEN_CONTRACT, ADDRESS_BOB, bob_value)
+    SESSION = (1, SESSION_SIDE_ALICE, SESSION_SIDE_BOB)
+
+    # On chain A, perform Propose as Alice
+    print("A: Propose")
+    propose_tx = swap_a.TransitionAlicePropose(swap_guid, SESSION)
+    propose_receipt = propose_tx.wait(raise_on_error=True)
+    propose_proof = proof_for_tx(rpc_a, proof_tx)
+    print(" - propose receipt", propose_receipt)
+    print(" - propose proof", propose_proof)
+
+    # Verify Alice's balance has reduced
+    require( token_a.balanceOf(ACCOUNT_ALICE) == 0 )
+    require( token_a.balanceOf(SWAP_CONTRACT) == alice_value )
+
+    # On chain B, perform Accept as Bob
+    link_wait(link_b, propose_proof)
+    print("B: Accept")
+    accept_tx = swap_b.TransitionBobAccept(swap_guid, SESSION, propose_proof)
+    accept_receipt = accept_tx.wait(raise_on_error=True)
+    accept_proof = proof_for_event(rpc_b, accept_tx, 0)
+    print(" - accept receipt", accept_receipt)
+    print(" - accept proof", accept_proof)
+
+    # Verify Bob's balance has reduced
+    require( token_b.balanceOf(ACCOUNT_BOB) == 0 )
+    require( token_b.balanceOf(SWAP_CONTRACT) == bob_value )
+
+    # On chain B, perform Withdraw as Alice
+    print("B: Alice Withdraw")
+    alice_withdraw_tx = swap_b.TransitionAliceWithdraw(swap_guid)
+    alice_withdraw_receipt = alice_withdraw_tx.wait()
+    print(" - alice withdraw receipt", alice_withdraw_receipt)
+
+    # Verify Alice now has bob's tokens
+    require( token_b.balanceOf(ACCOUNT_ALICE) == bob_value )
+    require( token_b.balanceOf(SWAP_CONTRACT) == 0 )
+
+    # On chain A, perform Withdraw as Bob
+    print("A: Bob Withdraw")
+    bob_withdraw_tx = swap_a.TransitionBobWithdraw( swap_guid, accept_proof )
+    bob_withdraw_receipt = bob_withdraw_tx.wait()
+    print(" - bob withdraw receipt", bob_withdraw_receipt)
+
+    # Verify Bob now has Alice's tokens
+    require( token_a.balanceOf(ACCOUNT_BOB) == alice_value )
+    require( token_a.balanceOf(SWAP_CONTRACT) == 0 )
 
 if __name__ == "__main__":
     main()

--- a/python/panautomata/example/swap.py
+++ b/python/panautomata/example/swap.py
@@ -1,9 +1,15 @@
 # Copyright (c) 2018 HarryR. All Rights Reserved.
 # SPDX-License-Identifier: GPL-3.0+
 
+from random import randint
 from enum import IntEnum
 
-import click
+
+SWAP_CONTRACT = '0x254dffcd3277c0b1660f6d42efbb754edababc2b'
+TOKEN_CONTRACT = '0xc89ce4735882c9f0f0fe26686c53074e09b0d550'
+
+ACCOUNT_A = '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1'
+ACCOUNT_B = '0xffcf8fdee72ac11b5c542428b35eef5769c409f0'
 
 
 class SwapState(IntEnum):
@@ -100,50 +106,19 @@ class SwapManager(object):
         return SwapProposal(swap, proposal)
 
 
-@click.command(help="Alice Propose")
-def alice_propose():
-    pass
+def main():
+    rpc_a = EthJsonRpc('127.0.0.1', 8545)
+    link_a = rpc_a.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDRESS)
+    swap_a = rpc_a.proxy('../solidity/build/contracts/ExampleSwap.json', SWAP_CONTRACT, ACCOUNT_A)
+    token_a = rpc_a.proxy('../solidity/build/contracts/ExampleERC20Token.json', TOKEN_CONTRACT ACCOUNT_A)
 
+    rpc_b = EthJsonRpc('127.0.0.1', 8546)
+    link_b = rpc_b.proxy('../solidity/build/contracts/LithiumLink.json', LINK_ADDRESS)
+    swap_b = rpc_b.proxy('../solidity/build/contracts/ExampleSwap.json', SWAP_CONTRACT ACCOUNT_B)
+    token_b = rpc_b.proxy('../solidity/build/contracts/ExampleERC20Token.json', TOKEN_CONTRACT ACCOUNT_B)
 
-@click.command(help="Alice Cancel")
-def alice_cancel():
-    pass
-
-
-@click.command()
-def alice_refund():
-    pass
-
-
-@click.command()
-def alice_withdraw():
-    pass
-
-
-@click.command()
-def bob_accept():
-    pass
-
-
-@click.command()
-def bob_reject():
-    pass
-
-
-@click.command()
-def bob_withdraw():
-    pass
-
-
-COMMANDS = click.Group("swap", help="ExampleSwap wrapper")
-COMMANDS.add_command(alice_propose)
-COMMANDS.add_command(alice_cancel)
-COMMANDS.add_command(alice_refund)
-COMMANDS.add_command(alice_withdraw)
-COMMANDS.add_command(bob_accept)
-COMMANDS.add_command(bob_reject)
-COMMANDS.add_command(bob_withdraw)
-
+    swap_guid = randint(1, 1<<255)
+    
 
 if __name__ == "__main__":
-    COMMANDS.main()
+    main()

--- a/python/panautomata/lithium/common.py
+++ b/python/panautomata/lithium/common.py
@@ -134,6 +134,8 @@ def process_transaction_and_logs(rpc, tx_hash):
     items = [transaction]
 
     log_items, log_count = process_logs(rpc, tx_hash)
+    # print("Log items Hashed", [hexlify(keccak_256(_).digest()) for _ in log_items])
+    # print("Log items Unhashed", [hexlify(_) for _ in log_items])
     items += log_items
     return items, log_count
 

--- a/python/panautomata/lithium/proofserver.py
+++ b/python/panautomata/lithium/proofserver.py
@@ -33,6 +33,10 @@ def main(rpc=None):
     if rpc is None:
         rpc = EthJsonRpc()
 
+    if not isinstance(rpc, EthJsonRpc):
+        host, port = rpc.split(':')
+        rpc = EthJsonRpc(host, port)
+
     proof_bp = ProofBlueprint(rpc)
 
     app = Flask(__name__)

--- a/solidity/contracts/Panautoma.sol
+++ b/solidity/contracts/Panautoma.sol
@@ -33,11 +33,13 @@ library RemoteContractLib
     {
         // TODO: verify self.nid equals LithiumLink.NetworkId()
 
-        bytes32 leaf_hash = keccak256(abi.encodePacked(
+        bytes memory leaf_data = abi.encodePacked(
             self.addr,
             in_event_sig,   // topic
             keccak256(in_event_args)
-        ));
+        );
+
+        bytes32 leaf_hash = keccak256(leaf_data);
 
         return self.prover.Verify(leaf_hash, in_proof);
     }

--- a/solidity/contracts/example/ExampleERC20Token.sol
+++ b/solidity/contracts/example/ExampleERC20Token.sol
@@ -8,6 +8,11 @@ contract ExampleERC20Token is MintableToken {
     string public symbol = "TEST";
     uint8 public decimals = 18;
 
+    modifier hasMintPermission() {
+        _;
+    }
+
+
     function getCurrentOwner() public view returns (address) {
         return msg.sender;
     }

--- a/solidity/contracts/example/ExampleSwap.sol
+++ b/solidity/contracts/example/ExampleSwap.sol
@@ -135,25 +135,21 @@ contract ExampleSwap
 
     // Events emitted after state transitions
     event OnAlicePropose( uint256 guid, Swap swap );
-    bytes32 constant public SIG_ON_ALICE_PROPOSE = keccak256("OnAlicePropose(uint256)");
 
     event OnAliceWithdraw( uint256 guid );
-    bytes32 constant public SIG_ON_ALICE_WITHDRAW = keccak256("OnAliceWithdraw(uint256)");
 
     event OnAliceRefund( uint256 guid );
-    bytes32 constant public SIG_ON_ALICE_REFUND = keccak256("OnAliceRefund(uint256)");
 
     event OnAliceCancel( uint256 guid );
-    bytes32 constant public SIG_ON_ALICE_CANCEL = keccak256("OnAliceCancel(uint256)");
+    bytes32 constant public SIG_ON_ALICE_CANCEL = keccak256(abi.encodePacked("OnAliceCancel(uint256)"));
 
     event OnBobAccept( uint256 guid );
-    bytes32 constant public SIG_ON_BOB_ACCEPT = keccak256("OnBobAccept(uint256)");
+    bytes32 constant public SIG_ON_BOB_ACCEPT = keccak256(abi.encodePacked("OnBobAccept(uint256)"));
 
     event OnBobReject( uint256 guid );
-    bytes32 constant public SIG_ON_BOB_REJECT = keccak256("OnBobReject(uint256)");
+    bytes32 constant public SIG_ON_BOB_REJECT = keccak256(abi.encodePacked("OnBobReject(uint256)"));
 
     event OnBobWithdraw( uint256 guid );
-    bytes32 constant public SIG_ON_BOB_WITHDRAW = keccak256("OnBobWithdraw(uint256)");
 
   
     function TransitionAlicePropose ( uint256 in_guid, Swap in_swap )
@@ -188,11 +184,11 @@ contract ExampleSwap
         require( in_swap.bob.swap_contract.addr == address(this) );
 
         require( in_swap.alice.swap_contract.VerifyTransaction(
-            in_swap.alice.addr,                 // from
-            0,                                  // value
-            this.TransitionAlicePropose.selector,    // selector
-            abi.encode(in_guid, in_swap),       // args
-            in_proof                            // proof
+            in_swap.alice.addr,                     // from
+            0,                                      // value
+            this.TransitionAlicePropose.selector,   // selector
+            abi.encode(in_guid, in_swap),           // args
+            in_proof                                // proof
         ));
 
         in_swap.state = State.AliceCancel;
@@ -306,12 +302,17 @@ contract ExampleSwap
 
         require( in_swap.bob.swap_contract.addr == address(this) );
 
+        require( in_swap.alice.swap_contract.VerifyTransaction(
+            in_swap.alice.addr,                     // from
+            0,                                      // value
+            this.TransitionAlicePropose.selector,   // selector
+            abi.encode(in_guid, in_swap),           // args
+            in_proof                                // proof
+        ));
+
         in_swap.state = State.BobReject;
 
         swaps[in_guid] = in_swap;
-
-        // Must provide proof of OnAlicePropose
-        require( in_swap.alice.swap_contract.VerifyEvent(SIG_ON_ALICE_PROPOSE, abi.encode(in_guid, in_swap), in_proof) );
 
         emit OnBobReject( in_guid );
     }
@@ -326,7 +327,7 @@ contract ExampleSwap
         require( swap.alice.swap_contract.addr == address(this) );
 
         // Must provide proof of BobAccept
-        require( swap.bob.swap_contract.VerifyEvent( SIG_ON_BOB_ACCEPT, abi.encode(in_guid), in_proof ) );
+        require( true == swap.bob.swap_contract.VerifyEvent( SIG_ON_BOB_ACCEPT, abi.encode(in_guid), in_proof ) );
 
         swap.state = State.BobWithdraw;
 

--- a/solidity/contracts/example/ExampleSwap.sol
+++ b/solidity/contracts/example/ExampleSwap.sol
@@ -161,6 +161,8 @@ contract ExampleSwap
     {
         require( SwapDoesNotExist(in_guid) );
 
+        require( in_swap.state == State.AlicePropose );
+
         require( in_swap.alice.swap_contract.addr == address(this) );
 
         swaps[in_guid] = in_swap;
@@ -184,6 +186,8 @@ contract ExampleSwap
         require( SwapDoesNotExist(in_guid) );
 
         require( in_swap.bob.swap_contract.addr == address(this) );
+
+        in_swap.state = State.AliceCancel;
 
         swaps[in_guid] = in_swap;
 
@@ -269,7 +273,11 @@ contract ExampleSwap
         // Swap must not already exist on Bobs chain to Accept
         require( SwapDoesNotExist(in_guid) );
 
+        require( in_swap.state == State.AlicePropose );
+
         require( in_swap.bob.swap_contract.addr == address(this) );
+
+        in_swap.state = State.BobAccept;
 
         swaps[in_guid] = in_swap;
 
@@ -295,6 +303,8 @@ contract ExampleSwap
         require( SwapDoesNotExist(in_guid) );
 
         require( in_swap.bob.swap_contract.addr == address(this) );
+
+        in_swap.state = State.BobReject;
 
         swaps[in_guid] = in_swap;
 


### PR DESCRIPTION
This fixes most of the ExampleSwap contract and implements a client-side end-to-end test for the swap logic.

However, the `BobWithdraw` function doesn't accept the proof, and I've been unable to determine exactly why without further debugging.

When the `VerifyEvent` line from `BobWithdraw` is commented out everything works as expected.